### PR TITLE
remove strong from wrapStyleElements

### DIFF
--- a/jquery.a11y.js
+++ b/jquery.a11y.js
@@ -20,7 +20,7 @@
             "nativeEnterElements": "textarea, a, button, input[type='checkbox'], input[type='radio']",
             "nativeTabElements": "textarea, input, select",
             "wrapIgnoreElements": "a,button,input,select,textarea,br",
-            "wrapStyleElements": "b,i,abbr,strong",
+            "wrapStyleElements": "b,i,abbr",
             "globalTabIndexElements": 'a,button,input,select,textarea,[tabindex]',
             "focusableElements": "a,button,input,select,textarea,[tabindex]",
             "focusableElementsAccessible": ":not(a,button,input,select,textarea)[tabindex]",


### PR DESCRIPTION
"strong" is a semantic element of the same order as "em". It should be treated like "em" and not like the presentational elements "b,i,abbr". Removed "strong" from "wrapStyleElements".